### PR TITLE
Aggregate life expectancy by unique income regions

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -1,4 +1,82 @@
-{
+# 검증 출력: 개수, 샘플, 교차 집합 수
+life_exp_sigungu = set(life_expectancy['시군구'].unique())
+avg_income_sigungu = set(average_income['시군구'].unique())
+
+print(f"life_expectancy 시군구 개수: {len(life_exp_sigungu)}")
+print(f"average_income 시군구 개수: {len(avg_income_sigungu)}")
+print(f"공통 시군구 개수: {len(life_exp_sigungu & avg_income_sigungu)}")
+
+# 경기도 성남시, 수원시 등 확인
+for city in ['경기도고양시', '경기도성남시', '경기도수원시', '경기도안산시', '경기도안양시', '경기도용인시', '충청북도청주시', '충청남도천안시']:
+    subset = life_expectancy[life_expectancy['시군구'] == city]
+    print(f"\n{city} rows: {len(subset)}")
+    if len(subset) > 0:
+        print(subset.head())# average_income에만 있는 시군구 Prefix를 기준으로 life_expectancy 세분구(구/군) 평균 내어 시 단위로 병합
+import numpy as np
+
+# 평균을 낼 수 있는 수치형 컬럼 자동 탐지 (성별, 시군구 제외)
+numeric_cols = life_expectancy.select_dtypes(include=[np.number]).columns.tolist()
+
+life_exp_sigungu = set(life_expectancy['시군구'].unique())
+avg_income_sigungu = set(average_income['시군구'].unique())
+
+avg_only_prefixes = sorted(list(avg_income_sigungu - life_exp_sigungu))
+print(f"average_income에만 있는 시군구 후보 수: {len(avg_only_prefixes)}")
+
+aggregated_rows = []
+rows_to_drop_idx = []
+
+for city_name in avg_only_prefixes:
+    # 해당 city_name으로 시작하는 세분 시군구 추출
+    mask = life_expectancy['시군구'].str.startswith(city_name)
+    if not mask.any():
+        continue
+    sub = life_expectancy[mask].copy()
+    # 성별별 평균 계산
+    grouped = sub.groupby('성별', as_index=False)[numeric_cols].mean()
+    # city-level 시군구명으로 치환한 행 구성
+    grouped['시군구'] = city_name
+    # 컬럼 순서 life_expectancy와 동일하게 정렬
+    grouped = grouped[['성별', '시군구'] + numeric_cols]
+    aggregated_rows.append(grouped)
+    # 원본 세분화 행들은 제거 대상 기록
+    rows_to_drop_idx.extend(sub.index.tolist())
+
+# 원본에서 세분구 행 제거
+if rows_to_drop_idx:
+    life_expectancy = life_expectancy.drop(index=rows_to_drop_idx).reset_index(drop=True)
+
+# 집계 행 추가
+if aggregated_rows:
+    life_expectancy = pd.concat([life_expectancy] + aggregated_rows, ignore_index=True)
+
+print("집계 처리 완료")
+print(f"현재 life_expectancy 시군구 개수: {len(life_expectancy['시군구'].unique())}")
+
+# 샘플 확인: 경기도고양시
+print("\n샘플 확인 - 경기도고양시:")
+print(life_expectancy[life_expectancy['시군구'] == '경기도고양시'].head())# 도/특별자치도 명칭 일괄 정규화 (life_expectancy)
+# average_income와 일치하도록 전라북도 → 전북특별자치도 등 매핑
+province_map = {
+    '강원도': '강원특별자치도',
+    '전라북도': '전북특별자치도',
+    '전라남도': '전남',  # 확인 필요시 아래에서 다시 교정
+    '충청북도': '충청북도',
+    '충청남도': '충청남도',
+}
+
+# 우선 강원도는 이미 위에서 치환됨. 전라북도만 추가 치환
+life_expectancy['시군구'] = life_expectancy['시군구'].str.replace('^전라북도', '전북특별자치도', regex=True)
+
+# 필요시 전라남도→전남특별자치도 등 추가 치환 (현재 데이터에 그런 변화는 없음)
+# life_expectancy['시군구'] = life_expectancy['시군구'].str.replace('^전라남도', '전남특별자치도', regex=True)
+
+# 재계산된 차이 확인
+life_exp_sigungu = set(life_expectancy['시군구'].unique())
+avg_income_sigungu = set(average_income['시군구'].unique())
+
+print(f"life_expectancy에만 있는 시군구: {len(life_exp_sigungu - avg_income_sigungu)}개")
+print(f"average_income에만 있는 시군구: {len(avg_income_sigungu - life_exp_sigungu)}개"){
   "cells": [
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Consolidate `life_expectancy` sub-district data into city-level averages to match `average_income` granularity.

The `life_expectancy` dataset contained detailed sub-district information (e.g., '경기도고양시 덕양구'), while `average_income` had only city-level entries (e.g., '경기도고양시'). This change identifies `시군구` names present only at the city-level in `average_income`, then aggregates all corresponding sub-district rows in `life_expectancy` by averaging their numeric columns per gender. The original sub-district rows are replaced with these new city-level average rows, ensuring consistent data granularity for further analysis. Province names like '전라북도' were also normalized to '전북특별자치도' for better alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-da01fb17-9d3d-4866-a66d-1ec96acc743f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da01fb17-9d3d-4866-a66d-1ec96acc743f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

