### PR TITLE
Aggregate life expectancy by unique income regions

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -1,4 +1,105 @@
-{
+# 통합 작업 완료 후 시군구 개수 확인
+life_exp_sigungu_final = set(life_expectancy['시군구'].unique())
+avg_income_sigungu_final = set(average_income['시군구'].unique())
+
+print("통합 작업 완료 후 시군구 개수 비교:")
+print(f"life_expectancy 시군구 개수: {len(life_exp_sigungu_final)}")
+print(f"average_income 시군구 개수: {len(avg_income_sigungu_final)}")
+
+# 여전히 차이가 나는 시군구들 확인
+still_diff_life = life_exp_sigungu_final - avg_income_sigungu_final
+still_diff_avg = avg_income_sigungu_final - life_exp_sigungu_final
+
+print(f"\n여전히 life_expectancy에만 있는 시군구: {len(still_diff_life)}개")
+if still_diff_life:
+    print("  -", list(still_diff_life)[:10], "..." if len(still_diff_life) > 10 else "")
+
+print(f"\n여전히 average_income에만 있는 시군구: {len(still_diff_avg)}개")
+if still_diff_avg:
+    print("  -", list(still_diff_avg)[:10], "..." if len(still_diff_avg) > 10 else "")
+
+# 공통 시군구 개수
+common_sigungu = life_exp_sigungu_final & avg_income_sigungu_final
+print(f"\n공통 시군구 개수: {len(common_sigungu)}개")# 통합된 데이터를 DataFrame으로 변환
+if consolidated_data:
+    consolidated_df = pd.DataFrame(consolidated_data)
+    print("통합된 데이터:")
+    print(consolidated_df.head(10))
+    
+    # 원본 life_expectancy에서 통합된 시군구들로 시작하는 행들을 제거
+    rows_to_remove = []
+    for target_sigungu in avg_only_sigungu:
+        matching_indices = life_expectancy[life_expectancy['시군구'].str.startswith(target_sigungu)].index
+        rows_to_remove.extend(matching_indices)
+    
+    # 중복 제거
+    rows_to_remove = list(set(rows_to_remove))
+    
+    print(f"\n제거할 행 수: {len(rows_to_remove)}")
+    
+    # 해당 행들을 제거
+    life_expectancy_cleaned = life_expectancy.drop(rows_to_remove)
+    
+    # 통합된 데이터를 추가
+    life_expectancy_final = pd.concat([life_expectancy_cleaned, consolidated_df], ignore_index=True)
+    
+    print(f"\n최종 life_expectancy 데이터 크기: {life_expectancy_final.shape}")
+    print(f"원본: {life_expectancy.shape}")
+    print(f"제거 후: {life_expectancy_cleaned.shape}")
+    print(f"통합 후: {life_expectancy_final.shape}")
+    
+    # life_expectancy를 업데이트
+    life_expectancy = life_expectancy_final
+    
+else:
+    print("통합할 데이터가 없습니다.")# life_expectancy에서 각 시군구명으로 시작하는 컬럼들을 찾아서 평균을 구하고 통합
+import numpy as np
+
+# 통합할 데이터를 저장할 리스트
+consolidated_data = []
+
+# average_income에만 있는 각 시군구에 대해 처리
+for target_sigungu in avg_only_sigungu:
+    # life_expectancy에서 해당 시군구명으로 시작하는 컬럼들을 찾기
+    matching_rows = life_expectancy[life_expectancy['시군구'].str.startswith(target_sigungu)]
+    
+    if len(matching_rows) > 0:
+        print(f"\n'{target_sigungu}'로 시작하는 life_expectancy 컬럼들:")
+        print(f"  - {list(matching_rows['시군구'].values)}")
+        print(f"  - 총 {len(matching_rows)}개")
+        
+        # 각 성별별로 평균 계산
+        for gender in ['남성', '여성', '전체']:
+            gender_rows = matching_rows[matching_rows['성별'] == gender]
+            
+            if len(gender_rows) > 0:
+                # 평균 계산 (시군구 컬럼 제외)
+                numeric_cols = ['평균 기대수명', '보험료1분위', '보험료2분위', '보험료3분위', '보험료4분위', '보험료5분위', '기대수명격차']
+                avg_values = {}
+                
+                for col in numeric_cols:
+                    avg_values[col] = gender_rows[col].mean()
+                
+                # 통합된 행 생성
+                consolidated_row = {
+                    '성별': gender,
+                    '시군구': target_sigungu,
+                    **avg_values
+                }
+                
+                consolidated_data.append(consolidated_row)
+                print(f"    {gender}: 평균 계산 완료")
+    
+    else:
+        print(f"\n'{target_sigungu}'로 시작하는 life_expectancy 컬럼이 없습니다.")
+
+print(f"\n총 {len(consolidated_data)}개의 통합된 행이 생성되었습니다.")# average_income에만 있는 시군구들을 확인
+avg_only_sigungu = sorted(list(avg_income_sigungu - life_exp_sigungu))
+print("average_income에만 있는 시군구들:")
+for i, sigungu in enumerate(avg_only_sigungu):
+    print(f"  {i+1}. {sigungu}")
+
+print(f"\n총 {len(avg_only_sigungu)}개"){
   "cells": [
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Align `life_expectancy` `sigungu` granularity with `average_income` by averaging sub-regions for consistent data analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-49e7af39-c9a0-48db-949f-aca6ff71c8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49e7af39-c9a0-48db-949f-aca6ff71c8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

